### PR TITLE
feat: Auth Token 저장 기능 추가

### DIFF
--- a/src/bridge/AbstractVacBridge.tsx
+++ b/src/bridge/AbstractVacBridge.tsx
@@ -2,12 +2,14 @@ import { Path } from '@/routes/path';
 
 export interface AbstractVacBridge {
   back(): void;
-  
-  routeTo(path: Path, option: { replace?: boolean, popup?: boolean }): void;
-  
+
+  routeTo(path: Path, option: { replace?: boolean; popup?: boolean }): void;
+
   getDate(): Promise<Date>;
-  
+
   getAccessToken(): Promise<string | null>;
-  
+
   getRegisterToken(): Promise<string | null>;
+
+  saveAuthToken(accessToken: string, refreshToken: string): Promise<void>;
 }

--- a/src/bridge/DummyVacBridge.tsx
+++ b/src/bridge/DummyVacBridge.tsx
@@ -1,5 +1,5 @@
 import { AbstractVacBridge } from '@/bridge/AbstractVacBridge';
-import { Path, PATH, webviewPATH } from '@/routes/path';
+import { Path } from '@/routes/path';
 
 export class DummyVacBridge implements AbstractVacBridge {
   back(): void {
@@ -29,5 +29,13 @@ export class DummyVacBridge implements AbstractVacBridge {
   async getRegisterToken(): Promise<string | null> {
     console.log('getRegisterToken');
     return process.env.NEXT_PUBLIC_REGISTER_TOKEN ?? null;
+  }
+
+  async saveAuthToken(
+    accessToken: string,
+    refreshToken: string,
+  ): Promise<void> {
+    console.log('registerAuthToken');
+    console.log(accessToken, refreshToken);
   }
 }

--- a/src/bridge/VacBridge.tsx
+++ b/src/bridge/VacBridge.tsx
@@ -10,6 +10,7 @@ import { Path } from '@/routes/path';
 import { DatePickerMessage } from '@/bridge/ipc/message/date';
 import { AccessTokenMessage } from '@/bridge/ipc/message/access-token';
 import { RegisterTokenMessage } from '@/bridge/ipc/message/register-token';
+import { RegisterAuthTokenRequest } from '@/bridge/ipc/message/register-auth-token';
 
 export class VacBridge implements AbstractVacBridge {
   constructor(private vacgomIpc: VacgomAppIpc) {}
@@ -71,5 +72,18 @@ export class VacBridge implements AbstractVacBridge {
     });
 
     return response.data;
+  }
+
+  async saveAuthToken(
+    accessToken: string,
+    refreshToken: string,
+  ): Promise<void> {
+    await this.vacgomIpc.send<RegisterAuthTokenRequest>({
+      type: 'SaveAuthTokenRequest',
+      data: {
+        accessToken,
+        refreshToken,
+      },
+    });
   }
 }

--- a/src/bridge/ipc/message/register-auth-token.ts
+++ b/src/bridge/ipc/message/register-auth-token.ts
@@ -1,0 +1,9 @@
+import { VacgomIpcMessage } from '@/bridge/ipc/message/types';
+
+export type RegisterAuthTokenRequest = VacgomIpcMessage<
+  'SaveAuthTokenRequest',
+  {
+    accessToken: string;
+    refreshToken: string;
+  }
+>;


### PR DESCRIPTION
## 💎 PR Point

* 회원가입의 결과로 받은 accessToken과 registerToken을 앱에 등록하는 브릿지를 추가합니다.
* accessToken과 registerToken을 입력하면 자동으로 메인 페이지로 이동합니다.

---

## 📌스크린샷 (선택)
